### PR TITLE
Add new password policy to validate passwords on login

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/policy/ValidateOnLoginPasswordPolicyProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/ValidateOnLoginPasswordPolicyProvider.java
@@ -1,0 +1,26 @@
+package org.keycloak.policy;
+
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+public class ValidateOnLoginPasswordPolicyProvider implements PasswordPolicyProvider {
+    @Override
+    public PolicyError validate(RealmModel realm, UserModel user, String password) {
+        return null;
+    }
+
+    @Override
+    public PolicyError validate(String user, String password) {
+        return null;
+    }
+
+    @Override
+    public Object parseConfig(String value) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/policy/ValidateOnLoginPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/ValidateOnLoginPasswordPolicyProviderFactory.java
@@ -1,0 +1,54 @@
+package org.keycloak.policy;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.PasswordPolicy;
+
+public class ValidateOnLoginPasswordPolicyProviderFactory implements PasswordPolicyProviderFactory {
+
+    @Override
+    public String getDisplayName() {
+        return "Validate Policy on Login";
+    }
+
+    @Override
+    public String getConfigType() {
+        return null;
+    }
+
+    @Override
+    public String getDefaultConfigValue() {
+        return null;
+    }
+
+    @Override
+    public boolean isMultiplSupported() {
+        return false;
+    }
+
+    @Override
+    public PasswordPolicyProvider create(KeycloakSession session) {
+        return new ValidateOnLoginPasswordPolicyProvider();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return PasswordPolicy.VALIDATE_ON_LOGIN_ID;
+    }
+}

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.policy.PasswordPolicyProviderFactory
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.policy.PasswordPolicyProviderFactory
@@ -33,3 +33,4 @@ org.keycloak.policy.NotEmailPasswordPolicyProviderFactory
 org.keycloak.policy.RecoveryCodesWarningThresholdPasswordPolicyProviderFactory
 org.keycloak.policy.MaxAuthAgePasswordPolicyProviderFactory
 org.keycloak.policy.AgePasswordPolicyProviderFactory
+org.keycloak.policy.ValidateOnLoginPasswordPolicyProviderFactory

--- a/server-spi/src/main/java/org/keycloak/models/PasswordPolicy.java
+++ b/server-spi/src/main/java/org/keycloak/models/PasswordPolicy.java
@@ -47,6 +47,10 @@ public class PasswordPolicy implements Serializable {
 
     public static final String PASSWORD_AGE = "passwordAge";
 
+    public static final String VALIDATE_ON_LOGIN_ID = "validateOnLogin";
+
+    public static final String POLICY_ERROR_AUTH_NOTE = "POLICY_ERROR";
+
     private Map<String, Object> policyConfig;
     private Builder builder;
 
@@ -141,6 +145,10 @@ public class PasswordPolicy implements Serializable {
         } else {
             return -1;
         }
+    }
+
+    public boolean shouldValidateOnLogin() {
+        return policyConfig.containsKey(VALIDATE_ON_LOGIN_ID);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticatorUtil.java
@@ -32,6 +32,7 @@ import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.services.managers.AuthenticationManager;
@@ -49,6 +50,7 @@ import java.util.stream.Stream;
 
 import static org.keycloak.services.managers.AuthenticationManager.FORCED_REAUTHENTICATION;
 import static org.keycloak.services.managers.AuthenticationManager.SSO_AUTH;
+import static org.keycloak.services.managers.AuthenticationManager.USER_READ_ONLY;
 import static org.keycloak.services.managers.AuthenticationManager.PASSWORD_VALIDATED;
 
 public class AuthenticatorUtil {
@@ -63,6 +65,10 @@ public class AuthenticatorUtil {
         return "true".equals(authSession.getAuthNote(SSO_AUTH));
     }
 
+    public static boolean isUserReadOnlyAuthentication(AuthenticationSessionModel authSession) {
+        return "true".equals(authSession.getAuthNote(USER_READ_ONLY));
+    }
+
     public static boolean isForcedReauthentication(AuthenticationSessionModel authSession) {
         return "true".equals(authSession.getAuthNote(FORCED_REAUTHENTICATION));
     }
@@ -73,6 +79,10 @@ public class AuthenticatorUtil {
 
     public static boolean isForkedFlow(AuthenticationSessionModel authSession) {
         return authSession.getAuthNote(AuthenticationProcessor.FORKED_FROM) != null;
+    }
+
+    public static boolean hasPasswordPolicyError(AuthenticationSessionModel authSession) {
+        return "true".equals(authSession.getAuthNote(PasswordPolicy.POLICY_ERROR_AUTH_NOTE));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidatePassword.java
@@ -19,6 +19,7 @@ package org.keycloak.authentication.authenticators.directgrant;
 
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticatorUtil;
 import org.keycloak.events.Errors;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.KeycloakSession;
@@ -54,6 +55,17 @@ public class ValidatePassword extends AbstractDirectGrantAuthenticator {
             context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return;
         }
+
+        if (AuthenticatorUtil.hasPasswordPolicyError(context.getAuthenticationSession())) {
+            Response challengeResponse = errorResponse(
+                    Response.Status.UNAUTHORIZED.getStatusCode(),
+                    "invalid_grant",
+                    "User password no longer matches the password policy and must be changed"
+            );
+            context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
+            return;
+        }
+
         context.getAuthenticationSession().setAuthNote(AuthenticationManager.PASSWORD_VALIDATED, "true");
         context.success();
     }

--- a/services/src/main/java/org/keycloak/credential/PasswordCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/PasswordCredentialProvider.java
@@ -206,6 +206,15 @@ public class PasswordCredentialProvider implements CredentialProvider<PasswordCr
             return false;
         }
 
+        if (realm.getPasswordPolicy().shouldValidateOnLogin()){
+            // After the password has been validated successfully, check that it still matches the realm's password policy.
+            PolicyError error = session.getProvider(PasswordPolicyManagerProvider.class).validate(realm, user, input.getChallengeResponse());
+            if (error != null) {
+                logger.debug("User password no longer matches password policy");
+                session.getContext().getAuthenticationSession().setAuthNote(PasswordPolicy.POLICY_ERROR_AUTH_NOTE, "true");
+            }
+        }
+
         return true;
     }
 

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -149,6 +149,9 @@ public class AuthenticationManager {
     // clientSession note with flag that clientSession was authenticated through SSO cookie
     public static final String SSO_AUTH = "SSO_AUTH";
 
+    // authSession note with flag that is true if user is authenticated through read-only user backend (e.g. read-only LDAP)
+    public static final String USER_READ_ONLY = "USER_READ_ONLY";
+
     // authSession note with flag that is true if user is forced to re-authenticate by client (EG. in case of OIDC client by sending "prompt=login")
     public static final String FORCED_REAUTHENTICATION = "FORCED_REAUTHENTICATION";
 

--- a/themes/src/main/resources/theme/base/login/login-policy-error.ftl
+++ b/themes/src/main/resources/theme/base/login/login-policy-error.ftl
@@ -1,0 +1,17 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "header">
+        ${msg("passwordPolicyErrorTitle")}
+    <#elseif section = "form">
+    <div id="kc-terms-text">
+        ${kcSanitize(msg("passwordPolicyErrorMessage"))?no_esc}
+    </div>
+    <form class="form-actions" action="${url.loginAction}" method="POST">
+        <#if !userReadOnly>
+            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="continueToUpdate" id="kc-accept" type="submit" value="${msg("doContinue")}"/>
+        </#if>
+        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="cancelUpdate" id="kc-decline" type="submit" value="${msg("doCancel")}"/>
+    </form>
+    <div class="clearfix"></div>
+    </#if>
+</@layout.registrationLayout>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -307,6 +307,10 @@ delegationFailedMessage=You may close this browser window and go back to your co
 
 noAccessMessage=No access
 
+passwordPolicyErrorTitle=New password policy
+passwordPolicyErrorMessage=Your password no longer matches the password policy set by the administrator and therefore must be updated.\
+  Click Continue to update your password or click Cancel to go back to the login screen.
+
 invalidPasswordMinLengthMessage=Invalid password: minimum length {0}.
 invalidPasswordMaxLengthMessage=Invalid password: maximum length {0}.
 invalidPasswordMinDigitsMessage=Invalid password: must contain at least {0} numerical digits.


### PR DESCRIPTION
Previously, Keycloak would only validate the password policy for new users and password changes. However, it may be desired to force all existing users to update their passwords when the password policy has changed.

To accomplish this, this adds a new ValidateOnLogin password policy that can be configured per realm much like the existing password policies. When this policy is present, the password of the user will be validated against the current password policy on each login. This can be done for both, local users and users in the LDAP.

Closes #14150

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
